### PR TITLE
Add small changes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ make install
 make compile-contracts
 ```
 
+This generates a `Contracts` directory in `dapp/src`, as specified in `chanterelle.json`.
+
 ### 3. Start services and run migrations
 Note that both table creation and migration runs from within docker, to avoid having to install `psql` and `flyway` on the host machine.
 
@@ -73,7 +75,7 @@ make run-server
 ```
 
 ```sh
-`make frontend-start
+make frontend-start
 ```
 
 ## Detailed documentation

--- a/server/README.md
+++ b/server/README.md
@@ -9,7 +9,7 @@ You can test the server running
 
 ```bash
 > make run-server
-> curl localhost:9000
+> curl localhost:9000/config/contracts
 ```
 
 you should get a response like


### PR DESCRIPTION
1. describes location of generated purescript contracts
2. removes an extra back-tick
3. fix `server/README.md` with updated contracts route